### PR TITLE
chore: add CODEOWNERS for review request automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @unhappychoice


### PR DESCRIPTION
Restores Dependabot review request behavior. The deprecated `reviewers:` field in `dependabot.yml` stopped working in late 2025 — CODEOWNERS is now the supported mechanism.