### PR TITLE
fix(deps): bump qs to 6.15.2 in example to fix DoS vulnerability

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -14,6 +14,7 @@
         "@cycle/isolate": "^5.2.0",
         "@cycle/run": "^5.7.0",
         "pusher-js": "^8.4.0",
+        "qs": "^6.15.2",
         "xstream": "11.x.x"
       },
       "devDependencies": {
@@ -23,7 +24,6 @@
       }
     },
     "..": {
-      "name": "cycle-pusher",
       "version": "2.0.9",
       "dev": true,
       "license": "MIT",
@@ -1051,6 +1051,7 @@
       "resolved": "https://registry.npmjs.org/most/-/most-1.9.0.tgz",
       "integrity": "sha512-M7yHMcMGaclzEL6eg8Yh8PlAsaWfL/oSThF4+ZuWKM5CKXcbzmLh+qESwgZFzMKHJ+iVJwb28yFvDEOobI653w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@most/multicast": "^1.2.5",
         "@most/prelude": "^1.4.0",
@@ -1101,9 +1102,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -1251,6 +1252,7 @@
       "resolved": "https://registry.npmjs.org/snabbdom/-/snabbdom-3.6.3.tgz",
       "integrity": "sha512-W2lHLLw2qR2Vv0DcMmcxXqcfdBaIcoN+y/86SmHv8fn4DazEQSH6KN3TjZcWvwujW56OHiiirsbHWZb4vx/0fg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12.17.0"
       }

--- a/example/package.json
+++ b/example/package.json
@@ -9,6 +9,7 @@
     "@cycle/isolate": "^5.2.0",
     "@cycle/run": "^5.7.0",
     "pusher-js": "^8.4.0",
+    "qs": "^6.15.2",
     "xstream": "11.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
Dependabot security update for `qs` was failing on the default branch (`security_update_not_possible`) because `example/package-lock.json` was out of sync and could only resolve `qs` to 6.14.2, while the fixed version is 6.15.2.

This bumps `qs` to `^6.15.2` in `example/` (added as an explicit dependency to pin the resolution), fixing the DoS advisory (`qs.stringify` crashes on null/undefined entries in comma-format arrays).

## Verification
- `npm audit` in `example/`: **0 vulnerabilities**

Refs: Dependabot CI failure tracked in unhappychoice/oss-issue-opener#210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new runtime dependency to enhance the example application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->